### PR TITLE
메인 슬로건 이미지 위치 수정

### DIFF
--- a/pyconkr/static/css/pyconkr-teaser.css
+++ b/pyconkr/static/css/pyconkr-teaser.css
@@ -312,7 +312,6 @@ section a {
 }
 
 .header-box {
-  text-align: left;
   margin-bottom: 0;
   position: relative;
 }
@@ -490,4 +489,7 @@ footer {
     display: block;
     margin: 0 auto 10px auto;
   }
+}
+.align-left {
+  text-align: left;
 }

--- a/pyconkr/templates/base.html
+++ b/pyconkr/templates/base.html
@@ -78,8 +78,10 @@
         </div>
 
         <header class="teaser-header z-index-1" id="home">
-            <img class="img-slogan" src="{% static 'image/pyconkr-2018-slogan.png' %}">
-            <div class="box header-box white-text">
+            <div class="box header-box">
+                <img class="img-slogan" src="{% static 'image/pyconkr-2018-slogan.png' %}">
+            </div>
+            <div class="box header-box white-text align-left">
                 <img class="badge-dotted-fill-logo" src="{% static 'image/dotted-fill-logo.png' %}">
                 <p>파이콘 한국 2018</p>
                 <span>서울, 코엑스</span><br>


### PR DESCRIPTION
윈도우 크기가 일정 크기보다 커졌을 때 메인 슬로건 이미지가 우측으로 위치하는 현상 수정