### PR TITLE
제목 중복 제거 방법 변경

### DIFF
--- a/pyconkr/templates/base.html
+++ b/pyconkr/templates/base.html
@@ -69,10 +69,11 @@
 
 <main>
     <div class="container">
-        {% block content %}
-            {% if title %}<h1>{{ title }}</h1>{% endif %}
-            {{ base_content | safe }}
-        {% endblock %}
+        {% if title %}<h1>{{ title }}</h1>{% endif %}
+
+        {{ base_content | safe }}
+
+        {% block content %}{% endblock %}
     </div>
 
     {% block sponsors %}

--- a/pyconkr/templates/pyconkr/patron_list.html
+++ b/pyconkr/templates/pyconkr/patron_list.html
@@ -5,7 +5,6 @@
 
 {% block content %}
 <div>
-  <h1>{% trans "Patrons" %}</h1>
   <p>파이콘 한국 2018 을 후원해주신 개인 후원자 분들의 명단입니다. 후원해주셔서 감사합니다.</p>
   <div class="margin-top-20">
     <ul class="patrons media-list">


### PR DESCRIPTION
Tutorials, Sprints 목록 페이지를 포함하여 기존 페이지들이 title 이 content 블럭 밖에 있는걸 가정하고 만들어져 있습니다.
기존에 이런 가정을 하고 만들어진 페이지가 더 많을것으로 추정되어 base는 원래대로 복원하고 개인 후원 페이지에서 제목만 제외합니다.