### PR TITLE
개인후원자 목록에서 후원시 기입한 정보가 아닌 후원자의 프로필 데이터를 보여줌

### DIFF
--- a/pyconkr/templates/pyconkr/patron_list.html
+++ b/pyconkr/templates/pyconkr/patron_list.html
@@ -12,15 +12,17 @@
       <li class="media">
         <div class="pull-left">
           {% thumbnail obj.user.profile.image "128x128" crop="center" as im %}
-          <img class="media-patron" src="{{ im.url }}" alt="photo of {{ obj.name }}">
+          <img class="media-patron" src="{{ im.url }}" alt="photo of {{ obj.user.profile.name or obj.name }}">
           {% empty %}
           <img class="media-patron" src="{% static 'image/anonymous.png' %}">
           {% endthumbnail %}
         </div>
         <div class="media-body">
           <h4 class="media-heading">
-            {{ obj.name }}
-            {% if obj.company %}
+            {{ obj.user.profile.name or obj.name }}
+            {% if obj.user.profile.organization %}
+            / {{ obj.user.profile.organization }}
+            {% elif obj.company %}
             / {{ obj.company }}
             {% endif %}
           </h4>


### PR DESCRIPTION
후원시 잘못 기입했다거나 하는 이유로 후원한 뒤에 후원자 목록에 보여지는 이름이나 소속 단체 등을 변경하고 싶어할 수 있습니다.