### PR TITLE
모바일 페이지 컨테이너 padding 값 조정

### DIFF
--- a/pyconkr/static/css/pyconkr-media.css
+++ b/pyconkr/static/css/pyconkr-media.css
@@ -84,8 +84,8 @@
         height: 340px;
     }
     .container {
-        padding-left: 5px;
-        padding-right: 5px;
+        padding-left: 20px;
+        padding-right: 20px;
     }
     .container>.navbar-header,
     .container>.navbar-collapse {

--- a/pyconkr/static/css/pyconkr.css
+++ b/pyconkr/static/css/pyconkr.css
@@ -8,10 +8,10 @@
 
     -webkit-font-smoothing: antialiased;
     -webkit-text-size-adjust: 100%;
-    
+
     /* anti-aliasing for firefox */
     -moz-osx-font-smoothing: grayscale;
-    
+
     /* anti-aliasing for general */
     text-rendering: geometricPrecision;
 
@@ -141,7 +141,7 @@ input[type=file] {
 
 .navbar .navbar-logo {
     float: none;
-    padding: 5px 25px 5px 15px;
+    padding: 5px 25px 5px 0px;
 }
 
 .navbar .navbar-logo img {
@@ -667,7 +667,7 @@ footer .hosting {
     /* to remove bootstrap panel's 20px margin-bottom */
     margin-bottom: 0;
 }
- 
+
 @keyframes blink{
     0% { opacity:1; }
     50% { opacity:0; }


### PR DESCRIPTION
기존 모바일 페이지 전반의 좌우 간격이 조금은 좁다고 느껴져, 
가독성을 위해 컨테이너의 padding left, right 값을 5px에서 20px로 조정해 보았습니다.

바쁘신 와중에도 파이콘 준비로 힘써주셔서 항상 감사합니다~! 🙂👏

+) 컨테이너의 패딩 값을 조정하면서 파이콘 로고까지 영향을 받는 것을 놓쳤네요 ㅠ.ㅠ 로고의 패딩 값도 추가로 수정합니다! :)