### PR TITLE
스프린트 소개 페이지에서 URL 자동 링크

### DIFF
--- a/pyconkr/templates/pyconkr/sprintproposal_detail.html
+++ b/pyconkr/templates/pyconkr/sprintproposal_detail.html
@@ -39,7 +39,7 @@
         <h3>{% trans "Sprint Language" %}</h3>
         <div>{{ sprint.language|linebreaks }}</div>
         <h3>{% trans "Project brief" %}</h3>
-        <div>{{ sprint.project_brief|linebreaks }}</div>
+        <div>{{ sprint.project_brief|urlize|linebreaks }}</div>
         <h3>{% trans "Detailed description" %}</h3>
         <div>{{ sprint.contribution_desc|safe }}</div>
     </div>
@@ -47,7 +47,7 @@
     <hr>
     <div>
         <h3>{% trans "Project URL" %}</h3>
-        <div>{{ sprint.project_url|linebreaks }}</div>
+        <div>{{ sprint.project_url|urlize|linebreaks }}</div>
     </div>
     <hr>
 </div>


### PR DESCRIPTION
스프린트 소개 페이지에서 프로젝트 공식 URL이나 프로젝트에 대한 간단한 설명에 포함된 URL이 링크가 걸려있지 않아 불편한데, [`|urlize`](https://docs.djangoproject.com/en/2.0/ref/templates/builtins/#urlize) 필터를 걸어서 자동으로 링크가 걸리게 고쳤습니다.