### PR TITLE
스프린트 세부 페이지의 목록으로 동작 수정

### DIFF
--- a/pyconkr/templates/pyconkr/sprintproposal_detail.html
+++ b/pyconkr/templates/pyconkr/sprintproposal_detail.html
@@ -53,7 +53,7 @@
 </div>
 <br>
 
-<a href="{% url 'tutorial' %}" class="btn btn-default">
+<a href="{% url 'sprint' %}" class="btn btn-default">
     <span class="glyphicon glyphicon-chevron-left"></span> {% trans "Back to list" %}
 </a>
 {% if joined %}


### PR DESCRIPTION
스프린트 세부 페이지에서 `목록으로` 버튼 동작이 `tutorial`로 연결되어있었는데, 이를 `sprint`로 수정했습니다.