### PR TITLE
Use new DISQUS site

### DIFF
--- a/pyconkr/templates/disqus.html
+++ b/pyconkr/templates/disqus.html
@@ -2,7 +2,7 @@
 <h3>{% trans "Comments" %}</h3>
 <div id="disqus_thread"></div>
 <script type="text/javascript">
-    var disqus_shortname = 'pycon-korea-2017';
+    var disqus_shortname = 'pycon-korea';
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
Use new DISQUS site for PyCon Korea, not `pycon-korea-2017`.